### PR TITLE
fix: button margin in mobile view

### DIFF
--- a/src/CodeConverter.jsx
+++ b/src/CodeConverter.jsx
@@ -121,7 +121,7 @@ const CodeConverter = () => {
 
           <div className="w-full flex justify-center"> 
             <button 
-              className={`px-6 py-2 ${loading ? 'bg-gray-400' : 'bg-transparent'} border text-white font-semibold rounded-md`} 
+              className={`px-6 py-2 mb-3 md:mb-0 ${loading ? 'bg-gray-400' : 'bg-transparent'} border text-white font-semibold rounded-md`} 
               onClick={handleConvert} 
               disabled={loading}>
               {loading ? 'Converting...' : 'Convert'}


### PR DESCRIPTION
fixes #3 

Since the issue was already get resolved, but in mobile view, the 'Convert' button has no margin from the bottom.
So, I have added margin to Convert button in mobile view.