### PR TITLE
feat: add code formatting files and allow .vscode/ to be tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
 !.vscode/extensions.json
 .idea
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules/
+package.json
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,14 @@
+{
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "embeddedLanguageFormatting": "auto",
+  "endOfLine": "lf",
+  "insertPragma": false,
+  "proseWrap": "preserve",
+  "requirePragma": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "printWidth": 100
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
+  "files.eol": "\n",
+  "files.insertFinalNewline": true
+}


### PR DESCRIPTION
This fixes #27. 

While initially there might be quite a few changes applied to the project when user's save files (i.e., `formatting on save` will occur), going forward, there will be less `diffs` in each commit due to changes in formatting.

If possible, can the `hacktoberfest`, `hacktoberfest2024`, and `hacktoberfest-accepted` labels be added to this pull request as well? Thank you!