### PR TITLE
Added functionality to saved the language selection in local storage

### DIFF
--- a/src/CodeConverter.jsx
+++ b/src/CodeConverter.jsx
@@ -90,37 +90,43 @@ const CodeConverter = () => {
     swift: `print("Hello World")`,
   };
   useEffect(() => {
-    let saved = (JSON.parse(localStorage.getItem('SavedLang')) || {
+    let saved = localStorage.getItem('SavedLang');
+    if (saved) {
+      saved = JSON.parse(saved);
+    } else {
+      saved = {
+        Input: 'python',
+        Output: 'javascript',
+      };
+    }
+    
+      setInputLang(saved.Input);
+      setInputCode(defaultCodes[saved.Input]);
+      setOutputLang(saved.Output);
+  }, []); 
+
+  function handleChange(langType, newLang) {
+    let updated = JSON.parse(localStorage.getItem('SavedLang')) || {
       Input: 'python',
       Output: 'javascript',
-    });
-    setInputLang(saved.Input);
-    setInputCode(defaultCodes[saved.Input]);
-    setOutputLang(saved.Output);
-  },[]);
-
-function handleChange(langType, newLang) {
-  let updated = JSON.parse(localStorage.getItem('SavedLang')) || {
-    Input: 'python',
-    Output: 'javascript',
-  };
-  if (langType === 'input') {
-    setInputLang((prevInputLang) => {
-      updated.Input = newLang;
-      localStorage.setItem('SavedLang', JSON.stringify(updated)); // Update localStorage
-      setInputCode(defaultCodes[newLang]);
-      console.log('Lang Change');
-      return newLang; // Return the new input language
-    });
-  } else if (langType === 'output') {
-    setOutputLang((prevOutputLang) => {
-      updated.Output = newLang;
-      localStorage.setItem('SavedLang', JSON.stringify(updated)); // Update localStorage
-      setOutputCode(''); // After cahnging the output code refreshes the output code
-      return newLang; // Return the new output language
-    });
+    };
+    if (langType === 'input') {
+      setInputLang((prevInputLang) => {
+        updated.Input = newLang;
+        localStorage.setItem('SavedLang', JSON.stringify(updated)); // Update localStorage
+        setInputCode(defaultCodes[newLang]);
+        console.log('Lang Change');
+        return newLang; // Return the new input language
+      });
+    } else if (langType === 'output') {
+      setOutputLang((prevOutputLang) => {
+        updated.Output = newLang;
+        localStorage.setItem('SavedLang', JSON.stringify(updated)); // Update localStorage
+        setOutputCode(''); // After cahnging the output code refreshes the output code
+        return newLang; // Return the new output language
+      });
+    }
   }
-}
 
   useEffect(() => {
     loader.init().then((monaco) => {
@@ -251,7 +257,6 @@ function handleChange(langType, newLang) {
                         : 'border-black bg-white text-black'
                     } p-2 rounded-md w-full mb-3`}
                   >
-                    {console.log(inputLang)}
                     {inputLang.charAt(0).toUpperCase() + inputLang.slice(1)}
                   </MenuButton>
 
@@ -262,8 +267,9 @@ function handleChange(langType, newLang) {
                     {options.map((option) => (
                       <MenuItem key={option}>
                         <button
-                          onClick={() =>{handleChange('input', option);}
-                          }
+                          onClick={() => {
+                            handleChange('input', option);
+                          }}
                           className={`w-full text-left px-4 py-2 ${
                             isDarkMode
                               ? 'hover:bg-blue-500 bg-black text-white '
@@ -339,8 +345,9 @@ function handleChange(langType, newLang) {
                     {options.map((option) => (
                       <MenuItem key={option}>
                         <button
-                          onClick={() =>{handleChange('output', option);}
-                          }
+                          onClick={() => {
+                            handleChange('output', option);
+                          }}
                           className={`w-full text-left px-4 py-2 ${
                             isDarkMode
                               ? 'hover:bg-blue-500 bg-black text-white '

--- a/src/CodeConverter.jsx
+++ b/src/CodeConverter.jsx
@@ -89,10 +89,38 @@ const CodeConverter = () => {
   }`,
     swift: `print("Hello World")`,
   };
-
   useEffect(() => {
-    setInputCode(defaultCodes[inputLang]);
-  }, [inputLang]);
+    let saved = (JSON.parse(localStorage.getItem('SavedLang')) || {
+      Input: 'python',
+      Output: 'javascript',
+    });
+    setInputLang(saved.Input);
+    setInputCode(defaultCodes[saved.Input]);
+    setOutputLang(saved.Output);
+  },[]);
+
+function handleChange(langType, newLang) {
+  let updated = JSON.parse(localStorage.getItem('SavedLang')) || {
+    Input: 'python',
+    Output: 'javascript',
+  };
+  if (langType === 'input') {
+    setInputLang((prevInputLang) => {
+      updated.Input = newLang;
+      localStorage.setItem('SavedLang', JSON.stringify(updated)); // Update localStorage
+      setInputCode(defaultCodes[newLang]);
+      console.log('Lang Change');
+      return newLang; // Return the new input language
+    });
+  } else if (langType === 'output') {
+    setOutputLang((prevOutputLang) => {
+      updated.Output = newLang;
+      localStorage.setItem('SavedLang', JSON.stringify(updated)); // Update localStorage
+      setOutputCode(''); // After cahnging the output code refreshes the output code
+      return newLang; // Return the new output language
+    });
+  }
+}
 
   useEffect(() => {
     loader.init().then((monaco) => {
@@ -223,6 +251,7 @@ const CodeConverter = () => {
                         : 'border-black bg-white text-black'
                     } p-2 rounded-md w-full mb-3`}
                   >
+                    {console.log(inputLang)}
                     {inputLang.charAt(0).toUpperCase() + inputLang.slice(1)}
                   </MenuButton>
 
@@ -233,7 +262,8 @@ const CodeConverter = () => {
                     {options.map((option) => (
                       <MenuItem key={option}>
                         <button
-                          onClick={() => setInputLang(option)}
+                          onClick={() =>{handleChange('input', option);}
+                          }
                           className={`w-full text-left px-4 py-2 ${
                             isDarkMode
                               ? 'hover:bg-blue-500 bg-black text-white '
@@ -309,7 +339,8 @@ const CodeConverter = () => {
                     {options.map((option) => (
                       <MenuItem key={option}>
                         <button
-                          onClick={() => setOutputLang(option)}
+                          onClick={() =>{handleChange('output', option);}
+                          }
                           className={`w-full text-left px-4 py-2 ${
                             isDarkMode
                               ? 'hover:bg-blue-500 bg-black text-white '


### PR DESCRIPTION
I have added the capability to store the current Input and Output language selection which will persist in the next session as well... with the help of local Storage
I created a new function "handleChange" which handles all the changes made to the menuItem tag of input and output.

This solution successfully fixes the issue : #23 
This is my first Open Source Contribution so please let me know if any changes are required or if there are any problems!!
Also
The handler function "handleChange" which I made is used in input menuItem's onClick event listener some thing like this :
<img width="1111" alt="Screenshot 2024-10-18 at 8 04 41 PM" src="https://github.com/user-attachments/assets/2387088f-31f3-4bcc-88ea-a83220f81048">
and similarly for output menuItem as well.